### PR TITLE
Remove duplicate projection matrix call

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -136,7 +136,6 @@ size_t frameCounter = 0;
 
             BeginMode3D(camera);
 
-                rlSetMatrixProjection(MatrixPerspective(45.0f * DEG2RAD, (float)SCREEN_WIDTH / SCREEN_HEIGHT, 0.1f, 10000.0f));
                 rlSetMatrixProjection(MatrixPerspective(
                     DEG2RAD * camera.fovy,
                     (float)SCREEN_WIDTH / SCREEN_HEIGHT,


### PR DESCRIPTION
## Summary
- remove redundant `rlSetMatrixProjection` call

## Testing
- `gcc -fopenmp -o terrain src/*.c -Wall -std=c99 -D_DEFAULT_SOURCE -Wno-missing-braces -Wunused-result -O2 -D_DEFAULT_SOURCE -I. -I/home/jerry/raylib/src -I/home/jerry/raylib/src/external -I/usr/local/include -I/home/jerry/raylib/src/external/glfw/include -L. -L/home/jerry/raylib/src -L/home/jerry/raylib/src -L/usr/local/lib -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -latomic -DPLATFORM_DESKTOP -DPLATFORM_DESKTOP_GLFW` *(fails: 'raylib.h: No such file or directory')*

------
https://chatgpt.com/codex/tasks/task_e_683ff53b45408333a07b5fa1962451d8